### PR TITLE
Add docs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A simple gem to parse the [Odeon UK website](http://odeon.co.uk) and spit out us
 [![Gem Version](https://badge.fury.io/rb/odeon_uk.png)](http://badge.fury.io/rb/odeon_uk)
 [![Code Climate](https://codeclimate.com/github/andycroll/odeon_uk.png)](https://codeclimate.com/github/andycroll/odeon_uk)
 [![Build Status](https://travis-ci.org/andycroll/odeon_uk.png?branch=master)](https://travis-ci.org/andycroll/odeon_uk)
+[![Inline docs](http://inch-pages.github.io/github/andycroll/odeon_uk.png)](http://inch-pages.github.io/github/andycroll/odeon_uk)
 
 ## Installation
 


### PR DESCRIPTION
I just added the badge you requested to your README: ![Inline docs](http://inch-pages.github.io/github/andycroll/odeon_uk.png)

Your status page for this project is http://inch-pages.github.io/github/andycroll/odeon_uk

Thanks for giving this a shot!
